### PR TITLE
Silencer

### DIFF
--- a/color/converter.py
+++ b/color/converter.py
@@ -38,7 +38,7 @@ def convert_hex_str_to_rgba_str(hex_string, has_alpha):
     hexes = [hex_string[i:i + 2] for i in range(0, len(hex_string), 2)]
     rgba = hexes_to_rgbs(hexes)
     alpha = rgba[-1]
-    if alpha is 255 and not has_alpha:
+    if alpha == 255 and not has_alpha:
         rgba = rgba[:-1]
     rgba_str = rgbs_to_string(rgba)
 

--- a/colorpicker.py
+++ b/colorpicker.py
@@ -253,7 +253,7 @@ class RainmeterColorPickCommand(sublime_plugin.TextCommand):  # pylint: disable=
         else:
             # doing alpha calculation first so we do not need to catch ff and FF
             alpha = output[-2:]
-            if not has_alpha and alpha is "FF":
+            if not has_alpha and alpha == "FF":
                 output = output[:-2]
 
             # it can be either originally in lower or upper case

--- a/path/addon_path_provider.py
+++ b/path/addon_path_provider.py
@@ -20,7 +20,7 @@ def get_cached_addon_path():
     """Get the value of the #ADDONSPATH# variable."""
     settingspath = get_cached_setting_path()
     if not settingspath:
-        logger.error("#SETTINGSPATH# resolution required but was not found")
+        logger.info("#SETTINGSPATH# resolution required but was not found")
         return
 
     return os.path.join(settingspath, "Addons") + "\\"

--- a/path/plugin_path_provider.py
+++ b/path/plugin_path_provider.py
@@ -19,7 +19,7 @@ def get_cached_plugin_path():
     """Get the value of the #PLUGINSPATH# variable."""
     settingspath = get_cached_setting_path()
     if not settingspath:
-        logger.error("#SETTINGSPATH# resolution required but was not found")
+        logger.info("#SETTINGSPATH# resolution required but was not found")
         return
 
     return os.path.join(settingspath, "Plugins") + "\\"

--- a/path/program_path_provider.py
+++ b/path/program_path_provider.py
@@ -32,15 +32,19 @@ def _get_rainmeter_registry_key():
 
     not much we can do to handle that
     """
-    return winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Rainmeter")
-
+    try:
+        return winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Rainmeter")
+    except FileNotFoundError:
+        return None
 
 def get_rm_path_from_registry():
     """Registry."""
     rainmeter_key = _get_rainmeter_registry_key()
-    rainmeter_path = winreg.QueryValue(rainmeter_key, None)
-
-    return rainmeter_path
+    if rainmeter_key:
+        rainmeter_path = winreg.QueryValue(rainmeter_key, None)
+        return rainmeter_path
+    else:
+        return None
 
 
 def _executable_exists(rm_path):
@@ -83,14 +87,13 @@ def get_cached_program_path():
         rm_path = get_rm_path_from_registry()
 
     # Check if path exists and contains Rainmeter.exe
-    if not os.path.isdir(rm_path):
+    if     not rm_path \
+        or not os.path.isdir(rm_path):
         message = """Path to Rainmeter.exe could neither be found:
-
-                     * in the settings,
-                     * in the standard directory,
-                     * nor via registry.
-
-                     Check your \"rainmeter_path\" setting."""
+            • in the settings
+            • in the standard directory
+            • via registry
+            Check your \"rainmeter_path\" setting."""
         logger.info(message)
         return
 

--- a/path/skin_path_provider.py
+++ b/path/skin_path_provider.py
@@ -77,6 +77,8 @@ def get_path_from_portable_rm(rm_path, settings_path):
 
     In this case, the Skins folder is inside the rainmeter path.
     """
+    if not rm_path:
+        return None
     if os.path.samefile(rm_path, settings_path):
         logger.info("Skin path found in #PROGRAMPATH#" +
                     " because portable installation")

--- a/path_initializer.py
+++ b/path_initializer.py
@@ -157,9 +157,9 @@ def plugin_loaded():
     __handle_skin_path_init()
 
     padding = 16
-    logger.info("#PROGRAMPATH#:".ljust(padding) + get_cached_program_path())  # Rainmeter.exe
-    logger.info("#PROGRAMDRIVE#:".ljust(padding) + get_cached_program_drive())
-    logger.info("#SETTINGSPATH#:".ljust(padding) + get_cached_setting_path())  # Rainmeter.ini
-    logger.info("#SKINSPATH#:".ljust(padding) + get_cached_skin_path())  # Rainmeter/Skins path
-    logger.info("#PLUGINSPATH#:".ljust(padding) + get_cached_plugin_path())
-    logger.info("#ADDONSPATH#:".ljust(padding) + get_cached_addon_path())
+    logger.info("#PROGRAMPATH#:" .ljust(padding) + (get_cached_program_path()  or ''))  # Rainmeter.exe
+    logger.info("#PROGRAMDRIVE#:".ljust(padding) + (get_cached_program_drive() or ''))
+    logger.info("#SETTINGSPATH#:".ljust(padding) + (get_cached_setting_path()  or ''))  # Rainmeter.ini
+    logger.info("#SKINSPATH#:"   .ljust(padding) + (get_cached_skin_path()     or ''))  # Rainmeter/Skins path
+    logger.info("#PLUGINSPATH#:" .ljust(padding) + (get_cached_plugin_path()   or ''))
+    logger.info("#ADDONSPATH#:"  .ljust(padding) + (get_cached_addon_path()    or ''))

--- a/path_initializer.py
+++ b/path_initializer.py
@@ -93,7 +93,7 @@ def __handle_program_path_init():
                 logger.info("No valid Rainmeter.exe found. Retrying again.")
                 browse_file(on_rainmeter_exe_browsed)
 
-        browse_file(on_rainmeter_exe_browsed)
+        # browse_file(on_rainmeter_exe_browsed)
 
 
 def __handle_skin_path_init():


### PR DESCRIPTION
Suppresses a few disruptive errors
  - don't throw on non-existing regex path
  - don't ask for an exe path if none found
  - silence errors on missing settings path

and also fixes some 3.8 python issues (though the plugin isn't ported to run on py38)